### PR TITLE
Initial implementation of dragons breath recipe

### DIFF
--- a/fabric/build.gradle.kts
+++ b/fabric/build.gradle.kts
@@ -19,3 +19,7 @@ tasks.processResources {
 tasks.remapJar {
     archiveBaseName.set("${properties["mod_id"]}")
 }
+
+loom {
+    accessWidenerPath.set(File("src/main/resources/mushroommod.accesswidener"))
+}

--- a/fabric/src/main/java/com/lunabbie/mushroommod/mixin/BrewingRecipeRegistryMixin.java
+++ b/fabric/src/main/java/com/lunabbie/mushroommod/mixin/BrewingRecipeRegistryMixin.java
@@ -1,0 +1,17 @@
+package com.lunabbie.mushroommod.mixin;
+
+import com.lunabbie.mushroommod.ModItems;
+import net.minecraft.item.Items;
+import net.minecraft.recipe.BrewingRecipeRegistry;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(BrewingRecipeRegistry.class)
+public abstract class BrewingRecipeRegistryMixin {
+    @Inject(method = "registerDefaults", at = @At("TAIL"))
+    private static void addDragonBreathRecipe(CallbackInfo ci) {
+        BrewingRecipeRegistry.registerItemRecipe(Items.SPLASH_POTION, ModItems.PAINSHROOM, Items.LINGERING_POTION);
+    }
+}

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -16,5 +16,6 @@
   "depends": {
     "minecraft": "~${minecraft_version}",
     "fabricloader": ">=${loader_version}"
-  }
+  },
+  "accessWidener" : "mushroommod.accesswidener"
 }

--- a/fabric/src/main/resources/mushroommod.accesswidener
+++ b/fabric/src/main/resources/mushroommod.accesswidener
@@ -1,0 +1,2 @@
+accessWidener	v1	named
+accessible method net/minecraft/recipe/BrewingRecipeRegistry registerItemRecipe (Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;Lnet/minecraft/item/Item;)V

--- a/fabric/src/main/resources/mushroommod.mixins.json
+++ b/fabric/src/main/resources/mushroommod.mixins.json
@@ -4,7 +4,8 @@
   "package": "com.lunabbie.mushroommod.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "AbstractFurnaceBlockEntityMixin"
+    "AbstractFurnaceBlockEntityMixin",
+    "BrewingRecipeRegistryMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
Instead of being able to convert painshroom into dragons breath, it can be used as a substitute to craft lingering potions

Implements #12 